### PR TITLE
Resets Worker Status after 19:59

### DIFF
--- a/apps/wfh2/include/worker_state.hrl
+++ b/apps/wfh2/include/worker_state.hrl
@@ -1,8 +1,8 @@
 -record(worker_state, {
           id :: atom()
           , version = 0 :: integer()
-          , working_from = office :: {out_of_office, Info :: binary} | office
-          , default = office :: {out_of_office, binary()} | office
+          , working_from = office :: wfh2_worker:location()
+          , default = office :: wfh2_worker:location()
           , last_updated = erlang:timestamp() :: erlang:timestamp()
          }).
 

--- a/apps/wfh2/include/worker_status.hrl
+++ b/apps/wfh2/include/worker_status.hrl
@@ -1,0 +1,10 @@
+-record(worker_status, {
+          email :: binary()
+          , name :: binary()
+          , working_from
+          :: {default, wfh2_worker:location()}
+          | {todays_update, wfh2_worker:location()}
+         }).
+
+-type worker_status() :: #worker_status{}.
+

--- a/apps/wfh2/src/wfh2.app.src
+++ b/apps/wfh2/src/wfh2.app.src
@@ -1,6 +1,6 @@
 {application, 'wfh2',
  [{description, "A web service for keeping track of workers locations"},
-  {vsn, "1.0.2"},
+  {vsn, "1.0.3"},
   {registered, []},
   {mod, {'wfh2_app', []}},
   {applications,

--- a/apps/wfh2/src/wfh2_todays_status.erl
+++ b/apps/wfh2/src/wfh2_todays_status.erl
@@ -1,22 +1,12 @@
 -module(wfh2_todays_status).
 
+-include("../include/worker_status.hrl").
 -include("../include/worker_state.hrl").
 
--export([get/0
-        , working_from/2
-        , transform_worker_state/2]).
+-export([get_worker_statuses/1
+        , get_worker_status/2]).
 
-get() ->
-  AllWorkerStates = wfh2_worker:get_worker_states(),
-  AllWorkerStates.
-
--spec(transform_worker_state(WorkerState :: worker_state(), CurrentTimestamp ::
-                            erlang:datetime()) -> term()).
-transform_worker_state(WorkerState, CurrentTimestamp) ->
-  LastUpdatedOrDefault = working_from(WorkerState,
-                                      calendar:now_to_datetime(CurrentTimestamp)),
-  #{email => atom_to_binary(WorkerState#worker_state.id, utf8)
-   , working_from => LastUpdatedOrDefault }.
+-define(HOUR_OF_DAYCHANGE, 19).
 
 normalised_date({{Year, Month, Day}, {Hour, _, _}}, CutOffHour)
   when Hour > CutOffHour ->
@@ -26,14 +16,46 @@ normalised_date({{Year, Month, Day}, _}, _CutOffHour) ->
 
 working_from(WorkerState, CurrentDateTime) ->
   LastUpdated = calendar:now_to_datetime(WorkerState#worker_state.last_updated),
-  DateUpdateAppliesTo = normalised_date(LastUpdated, 19),
-  DateShouldGetUpdateFor = normalised_date(CurrentDateTime, 19),
+  DateUpdateAppliesTo = normalised_date(LastUpdated, ?HOUR_OF_DAYCHANGE),
+  DateShouldGetUpdateFor = normalised_date(CurrentDateTime, ?HOUR_OF_DAYCHANGE),
   ShouldGetCurrentUpdate =
   calendar:date_to_gregorian_days(DateShouldGetUpdateFor) =:=
   calendar:date_to_gregorian_days(DateUpdateAppliesTo),
-  WorkingFrom = if ShouldGetCurrentUpdate ->
-                     {todays_update, WorkerState#worker_state.working_from};
-                   true -> {default, WorkerState#worker_state.default}
-                end,
-  WorkingFrom.
+  if ShouldGetCurrentUpdate ->
+       {todays_update, WorkerState#worker_state.working_from};
+     true -> {default, WorkerState#worker_state.default}
+  end.
+
+get_worker_update(WorkerState, #{profile := Profile}, CurrentDateTime) ->
+  Id = WorkerState#worker_state.id,
+  WorkingFrom = working_from(WorkerState, CurrentDateTime),
+  Name = case maps:get(real_name, Profile, <<"">>) of
+           <<"">> -> Id;
+           Other -> Other
+         end,
+
+  #worker_status {
+     email = Id
+     , name = Name
+     , working_from = WorkingFrom}.
+
+get_profile_and_state(WorkerId, GetWorkerState, GetWorkerProfile) ->
+  State = GetWorkerState(WorkerId),
+  Profile = GetWorkerProfile(WorkerId),
+  {State, Profile}.
+
+get_worker_state(WorkerId) ->
+  {ok, State} = wfh2_worker:get_worker_state(WorkerId),
+  State.
+
+get_worker_profile(WorkerId) ->
+  sprof_cache:get_profile_for(WorkerId).
+
+get_worker_status(WorkerId, ForDateTime) ->
+  {WorkerState, WorkerProfile} = get_profile_and_state(WorkerId, fun get_worker_state/1, fun get_worker_profile/1),
+  get_worker_update(WorkerState, WorkerProfile, ForDateTime).
+
+get_worker_statuses(ForDateTime) ->
+  WorkerIds = wfh2_worker_sup:get_worker_ids(),
+  lists:map(fun (WorkerId) -> get_worker_status(WorkerId, ForDateTime) end, WorkerIds).
 

--- a/apps/wfh2/src/wfh2_worker_handler.erl
+++ b/apps/wfh2/src/wfh2_worker_handler.erl
@@ -12,10 +12,8 @@
         , get_json/2
         , put_json/2]).
 
--type(location () :: in_office | out_of_office).
-
 -record(rest_state, {worker_id :: atom(), action :: binary(), location ::
-                     location(), info:: binary() | undefined}).
+                     wfh2_worker:location(), info:: binary() | undefined}).
 
 init(_Proto, _Req, _Opts) ->
   {upgrade, protocol, cowboy_rest}.
@@ -47,9 +45,9 @@ options(Req,State) ->
 
 get_json(Req, State) ->
   WorkerId = State#rest_state.worker_id,
-  {ok, WorkerState} = wfh2_worker:get_worker_state(WorkerId),
-  WorkerProfile = sprof_cache:get_profile_for(WorkerId),
-  Body = wfh2_serialisation:encode_status({WorkerState, WorkerProfile}),
+  Now = calendar:now_to_datetime(erlang:timestamp()),
+  WorkerStatus = wfh2_todays_status:get_worker_status(WorkerId, Now),
+  Body = wfh2_serialisation:encode_status(WorkerStatus),
   {Body, Req, State}.
 
 get_post_request_data(Req) ->

--- a/apps/wfh2/test/wfh2_todays_status_tests.erl
+++ b/apps/wfh2/test/wfh2_todays_status_tests.erl
@@ -13,9 +13,10 @@ yesterday(Date) ->
 same_time_test() ->
   Now = erlang:timestamp(),
   CurrentDateTime = calendar:now_to_datetime(Now),
-  State = #worker_state{last_updated = Now, working_from = home, info = <<"def
-                                                                    home">>,
-                        default = office},
+  State = #worker_state{
+             last_updated = Now,
+             working_from = {out_of_office, <<"def home">>},
+             default = office},
   {DefaultOrTodays, _} = wfh2_todays_status:working_from(State, CurrentDateTime),
   ?assertEqual(DefaultOrTodays, todays_update).
 
@@ -26,7 +27,8 @@ updated_at_19_asking_next_day_at_9_should_return_default_test() ->
   YesterdayAt19 = {Yesterday, {19,0,0}},
   TodayAt9 = {Today, {9,0,0}},
   State = #worker_state{last_updated = convert_to_timestamp(YesterdayAt19),
-                        working_from = home, default = office},
+                        working_from = {out_of_office, <<"">>},
+                        default = office},
   {DefaultOrTodays, _} = wfh2_todays_status:working_from(State, TodayAt9),
   ?assertEqual(DefaultOrTodays, default).
 


### PR DESCRIPTION
Closes #13 
- extract worker status representation
- fixes unit tests
- fix dialyzer warnings after moving location()
- centralise worker_status representation
- let single resource use new path
- rename functions to match return type
- users that have never updated will receive a last updated never which
  maps to 2000,01,01
